### PR TITLE
Replace libgdbm3 with libgdbm5 on ubuntu 18.04 bionic

### DIFF
--- a/manifests/deps/debian.pp
+++ b/manifests/deps/debian.pp
@@ -3,6 +3,11 @@
 # This module manages rbenv dependencies for Debian $::osfamily.
 #
 class rbenv::deps::debian {
+  $libgdbm_package_name = $::os['distro']['codename'] ? {
+    'bionic' => 'libgdbm5',
+    default  => 'libgdbm3',
+  }
+
   ensure_packages([
     'build-essential',
     'git',
@@ -12,7 +17,7 @@ class rbenv::deps::debian {
     'libffi-dev',
     'libyaml-dev',
     'libncurses5-dev',
-    'libgdbm3',
+    $libgdbm_package_name,
     'libgdbm-dev',
     'patch'
     ])


### PR DESCRIPTION
The libgdbm3 package doesn't exist in Ubuntu 18.04 anymore (not sure about other versions). 