### PR TITLE
support old gem flags for no documentation in ruby 1.x

### DIFF
--- a/manifests/gem.pp
+++ b/manifests/gem.pp
@@ -69,8 +69,11 @@ define rbenv::gem(
     fail('You must declare a ruby_version for rbenv::gem')
   }
 
-  if ($skip_docs) {
-    $docs = '--no-document'
+  if $skip_docs {
+    $docs = $ruby_version ? {
+      /^1\./  => '--no-ri --no-rdoc',
+      default => '--no-document',
+    }
   } else {
     $docs = ''
   }


### PR DESCRIPTION
When installing the ancient ruby 1.9.3-p551 (don't ask) I found that the step to install the bundler gem failed throwing the following error: 

```
  Notice: /Stage[main]/Profile::Ruby/Rbenv::Build[1.9.3-p551]/Rbenv::Gem[bundler-1.9.3-p551]/Exec[ruby-1.9.3-p551-gem-install-bundler-_0]/returns: ERROR:  While executing gem ... (OptionParser::InvalidOption)
  Notice: /Stage[main]/Profile::Ruby/Rbenv::Build[1.9.3-p551]/Rbenv::Gem[bundler-1.9.3-p551]/Exec[ruby-1.9.3-p551-gem-install-bundler-_0]/returns:     invalid option: --no-document
```

So this PR goes back to `--no-ri --no-rdoc` flags to implement documentation install skipping when the version of ruby is 1.x. 

Example code I'm using to install the old ruby:

```
  class { 'rbenv':
    install_dir => '/opt/rbenv',
    latest      => false,
    manage_deps => false, # without this it will install openssl 1.1 development packages which don't let openssl 1.0 reliant rubies have ssl, eg ruby 1.9.3
  }

  # debian / ubuntu
  $deps = [
    'build-essential',
    'git',
    'libreadline-dev',
    # skip managing libssl1.0-dev because it is incompatible with libmysqldev and they fight with one another
    # 'libssl1.0-dev',
    'openssl1.0',
    'zlib1g-dev',
    'libffi-dev',
    'libyaml-dev',
    'libncurses5-dev',
    'libgdbm-dev',
    'patch',
  ]

  # required for ruby 1.9.3 on Ubuntu bionic
  package { $deps:
    ensure => installed,
  }

  rbenv::plugin { 'rbenv/ruby-build': }
  rbenv::build { '1.9.3-p551':
    global          => true,
    bundler_version => '1.17.3',
  }
```