### PR TITLE
Change owner attribute in Exec[git-pull-rubybuild-${name}]

### DIFF
--- a/manifests/build.pp
+++ b/manifests/build.pp
@@ -134,7 +134,7 @@ define rbenv::build (
   -> exec { "git-pull-rubybuild-${title}":
     command => 'git reset --hard HEAD && git pull',
     cwd     => "${install_dir}/plugins/ruby-build",
-    user    => 'root',
+    user    => $owner,
     unless  => "test -d ${install_dir}/versions/${title}",
     require => Rbenv::Plugin['rbenv/ruby-build'],
   }


### PR DESCRIPTION
This addresses issue #97
rspec passes locally