### PR TITLE
Resolve rbenv::build failures with multiple Ruby versions using the same RubyGems version

### DIFF
--- a/manifests/build.pp
+++ b/manifests/build.pp
@@ -155,7 +155,7 @@ define rbenv::build (
   # a series of issues like
   # https://bundler.io/blog/2019/05/14/solutions-for-cant-find-gem-bundler-with-executable-bundle.html.
   if $rubygems_version {
-    exec { "rubygems-${rubygems_version}":
+    exec { "rubygems-${rubygems_version}-for-${title}":
       command     => "gem update --system ${rubygems_version}",
       environment => ["RBENV_ROOT=${install_dir}"],
       require     => Exec["rbenv-install-${title}"],

--- a/spec/defines/build_spec.rb
+++ b/spec/defines/build_spec.rb
@@ -47,7 +47,7 @@ describe 'rbenv::build' do
         }
       end
 
-      it { is_expected.to contain_exec('rubygems-3.2.1') }
+      it { is_expected.to contain_exec('rubygems-3.2.1-for-2.0.0-p247') }
     end
 
     context 'with global => true' do


### PR DESCRIPTION
 Resolves failure with rbenv:build when the same version of rubygems is used in multiple versions of ruby.

Addresses #99; follow up to PR# https://github.com/jdowning/puppet-rbenv/pull/88